### PR TITLE
Version 2.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A TypeScript package for seamless Pesapal payments integration in Node.js powere
 ## 📦 Installation
 
 ```bash
-npm install pesapal-node-sdk axios dotenv
+npm install pesapal-node-sdk
 ```
 
 ## ⚙️ Configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pesapal-node-sdk",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Node.js SDK for integrating with Pesapal payment gateway. Provides a simple interface for processing payments, checking status, and handling callbacks.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/AuthService.test.ts
+++ b/tests/AuthService.test.ts
@@ -11,6 +11,7 @@ describe('AuthService', () => {
         apiUrl: 'https://test.api',
         callbackUrl: 'https://test/callback',
         ipnUrl: 'https://test/ipn',
+        ipnId: 'test_ipn_id',
     };
 
     it('authenticates successfully', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,18 @@
+// Set environment variables before any imports
+process.env.PESAPAL_CONSUMER_KEY = 'test_key';
+process.env.PESAPAL_CONSUMER_SECRET = 'test_secret';
+process.env.PESAPAL_CALLBACK_URL = 'https://test.com/callback';
+process.env.PESAPAL_IPN_URL = 'https://test.com/ipn';
+process.env.PESAPAL_IPN_ID = 'test_ipn_id';
+process.env.PESAPAL_ENV = 'sandbox';
+
+// Mock the services before importing
+jest.mock('../src/services/HttpClient');
+jest.mock('../src/services/AuthService');
+jest.mock('../src/services/PaymentService');
+
 import { paymentService, initializePesapal, PesapalConfigError } from '../src/index';
 import { PaymentService } from '../src/services/PaymentService';
-
-jest.mock('../src/pesapal');
 
 describe('Index Module', () => {
   afterEach(() => {
@@ -36,7 +47,7 @@ describe('Index Module', () => {
   describe('Re-exports from pesapal module', () => {
     it('should re-export initializePesapal function', () => {
       // Call the re-exported function to verify it works
-      const result = initializePesapal({ consumerKey: 'test' });
+      const result = initializePesapal();
       
       // Verify it returns a PaymentService instance
       expect(result).toBeInstanceOf(PaymentService);
@@ -47,7 +58,7 @@ describe('Index Module', () => {
       const error = new PesapalConfigError('test message');
       
       // Verify it's properly constructed
-      expect(error).toBeInstanceOf(Error);
+      expect(error instanceof Error).toBe(true);
       expect(error.name).toBe('PesapalConfigError');
       expect(error.message).toBe('test message');
     });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,55 @@
+import { paymentService, initializePesapal, PesapalConfigError } from '../src/index';
+import { PaymentService } from '../src/services/PaymentService';
+
+jest.mock('../src/pesapal');
+
+describe('Index Module', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Exports', () => {
+    it('should export paymentService instance', () => {
+      expect(paymentService).toBeDefined();
+      expect(paymentService).toBeInstanceOf(PaymentService);
+    });
+
+    it('should export initializePesapal function', () => {
+      expect(initializePesapal).toBeDefined();
+      expect(typeof initializePesapal).toBe('function');
+    });
+
+    it('should export PesapalConfigError class', () => {
+      expect(PesapalConfigError).toBeDefined();
+      expect(typeof PesapalConfigError).toBe('function');
+    });
+  });
+
+  describe('Default paymentService', () => {
+    it('should be created using initializePesapal with no arguments', () => {
+      // The default paymentService should be created by calling initializePesapal()
+      // This is tested indirectly by verifying the export exists and is a PaymentService instance
+      expect(paymentService).toBeInstanceOf(PaymentService);
+    });
+  });
+
+  describe('Re-exports from pesapal module', () => {
+    it('should re-export initializePesapal function', () => {
+      // Call the re-exported function to verify it works
+      const result = initializePesapal({ consumerKey: 'test' });
+      
+      // Verify it returns a PaymentService instance
+      expect(result).toBeInstanceOf(PaymentService);
+    });
+
+    it('should re-export PesapalConfigError class', () => {
+      // Create instance of re-exported class
+      const error = new PesapalConfigError('test message');
+      
+      // Verify it's properly constructed
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('PesapalConfigError');
+      expect(error.message).toBe('test message');
+    });
+  });
+});

--- a/tests/pesapal.test.ts
+++ b/tests/pesapal.test.ts
@@ -1,0 +1,217 @@
+import { initializePesapal, PesapalConfigError } from '../src/pesapal';
+import { PaymentService } from '../src/services/PaymentService';
+import { HttpClient } from '../src/services/HttpClient';
+import { AuthService } from '../src/services/AuthService';
+
+jest.mock('../src/services/HttpClient');
+jest.mock('../src/services/AuthService');
+jest.mock('../src/services/PaymentService');
+
+// Mock environment variables
+const originalEnv = process.env;
+
+describe('Pesapal SDK Initialization', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      PESAPAL_CONSUMER_KEY: 'test_key',
+      PESAPAL_CONSUMER_SECRET: 'test_secret',
+      PESAPAL_CALLBACK_URL: 'https://test.com/callback',
+      PESAPAL_IPN_URL: 'https://test.com/ipn',
+      PESAPAL_IPN_ID: 'test_ipn_id',
+      PESAPAL_ENV: 'sandbox'
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  describe('Configuration Validation', () => {
+    it('should throw PesapalConfigError when consumerKey is missing', () => {
+      delete process.env.PESAPAL_CONSUMER_KEY;
+      
+      expect(() => initializePesapal()).toThrow(PesapalConfigError);
+      expect(() => initializePesapal()).toThrow('Missing or empty required configuration fields: consumerKey');
+    });
+
+    it('should throw PesapalConfigError when consumerSecret is missing', () => {
+      delete process.env.PESAPAL_CONSUMER_SECRET;
+      
+      expect(() => initializePesapal()).toThrow(PesapalConfigError);
+      expect(() => initializePesapal()).toThrow('Missing or empty required configuration fields: consumerSecret');
+    });
+
+    it('should throw PesapalConfigError when callbackUrl is missing', () => {
+      delete process.env.PESAPAL_CALLBACK_URL;
+      
+      expect(() => initializePesapal()).toThrow(PesapalConfigError);
+      expect(() => initializePesapal()).toThrow('Missing or empty required configuration fields: callbackUrl');
+    });
+
+    it('should throw PesapalConfigError when ipnUrl is missing', () => {
+      delete process.env.PESAPAL_IPN_URL;
+      
+      expect(() => initializePesapal()).toThrow(PesapalConfigError);
+      expect(() => initializePesapal()).toThrow('Missing or empty required configuration fields: ipnUrl');
+    });
+
+    it('should throw PesapalConfigError when multiple fields are missing', () => {
+      delete process.env.PESAPAL_CONSUMER_KEY;
+      delete process.env.PESAPAL_CONSUMER_SECRET;
+      
+      expect(() => initializePesapal()).toThrow(PesapalConfigError);
+      expect(() => initializePesapal()).toThrow('Missing or empty required configuration fields: consumerKey, consumerSecret');
+    });
+
+    it('should throw PesapalConfigError when fields are empty strings', () => {
+      process.env.PESAPAL_CONSUMER_KEY = '';
+      process.env.PESAPAL_CONSUMER_SECRET = '   '; // whitespace only
+      
+      expect(() => initializePesapal()).toThrow(PesapalConfigError);
+      expect(() => initializePesapal()).toThrow('Missing or empty required configuration fields: consumerKey, consumerSecret');
+    });
+
+    it('should not throw error when all required fields are present', () => {
+      expect(() => initializePesapal()).not.toThrow();
+    });
+  });
+
+  describe('Configuration Override', () => {
+    it('should use provided config values over environment variables', () => {
+      const customConfig = {
+        consumerKey: 'custom_key',
+        consumerSecret: 'custom_secret'
+      };
+
+      initializePesapal(customConfig);
+      // Verify that HttpClient was called with merged config
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          consumerKey: 'custom_key',
+          consumerSecret: 'custom_secret',
+          callbackUrl: 'https://test.com/callback', // from env
+          ipnUrl: 'https://test.com/ipn', // from env
+          ipnId: 'test_ipn_id' // from env
+        })
+      );
+    });
+
+    it('should fall back to environment variables for missing config fields', () => {
+      const partialConfig = {
+        consumerKey: 'custom_key'
+        // Other fields should come from environment
+      };
+
+      initializePesapal(partialConfig);
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          consumerKey: 'custom_key',
+          consumerSecret: 'test_secret', // from env
+          callbackUrl: 'https://test.com/callback', // from env
+          ipnUrl: 'https://test.com/ipn', // from env
+          ipnId: 'test_ipn_id' // from env
+        })
+      );
+    });
+
+    it('should throw error when override config has empty required fields', () => {
+      const invalidConfig = {
+        consumerKey: '',
+        consumerSecret: 'valid_secret'
+      };
+
+      expect(() => initializePesapal(invalidConfig)).toThrow(PesapalConfigError);
+      expect(() => initializePesapal(invalidConfig)).toThrow('Missing or empty required configuration fields: consumerKey');
+    });
+
+    it('should handle live environment URL correctly', () => {
+      process.env.PESAPAL_ENV = 'live';
+      
+      initializePesapal();
+      
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiUrl: 'https://pay.pesapal.com/v3/api'
+        })
+      );
+    });
+
+    it('should default to sandbox URL for non-live environment', () => {
+      process.env.PESAPAL_ENV = 'sandbox';
+      
+      initializePesapal();
+      
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiUrl: 'https://cybqa.pesapal.com/pesapalv3/api'
+        })
+      );
+    });
+
+    it('should allow custom apiUrl override', () => {
+      const customConfig = {
+        apiUrl: 'https://custom-api.com/v3/api'
+      };
+
+      initializePesapal(customConfig);
+      
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiUrl: 'https://custom-api.com/v3/api'
+        })
+      );
+    });
+  });
+
+  describe('Service Initialization', () => {
+    it('should create PaymentService with all required dependencies', () => {
+      const result = initializePesapal();
+      
+      expect(HttpClient).toHaveBeenCalledTimes(1);
+      expect(AuthService).toHaveBeenCalledTimes(1);
+      expect(PaymentService).toHaveBeenCalledTimes(1);
+      expect(result).toBeInstanceOf(PaymentService);
+    });
+
+    it('should pass config to all services', () => {
+      initializePesapal();
+      
+      const expectedConfig = {
+        consumerKey: 'test_key',
+        consumerSecret: 'test_secret',
+        apiUrl: 'https://cybqa.pesapal.com/pesapalv3/api',
+        callbackUrl: 'https://test.com/callback',
+        ipnUrl: 'https://test.com/ipn',
+        ipnId: 'test_ipn_id'
+      };
+
+      expect(HttpClient).toHaveBeenCalledWith(expectedConfig);
+      expect(AuthService).toHaveBeenCalledWith(
+        expect.any(Object), // HttpClient instance
+        expectedConfig
+      );
+      expect(PaymentService).toHaveBeenCalledWith(
+        expect.any(Object), // AuthService instance
+        expect.any(Object), // HttpClient instance
+        expectedConfig
+      );
+    });
+  });
+
+  describe('PesapalConfigError', () => {
+    it('should be an instance of Error', () => {
+      const error = new PesapalConfigError('test message');
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('PesapalConfigError');
+      expect(error.message).toBe('test message');
+    });
+
+    it('should have correct error name', () => {
+      const error = new PesapalConfigError('test');
+      expect(error.name).toBe('PesapalConfigError');
+    });
+  });
+});


### PR DESCRIPTION
This PR handles the issues arising from issue: [https://github.com/otim-otim/pesapal-node-sdk/issues/1](url) . For backward compatibility, allows the package to still seek variables from the .env, if no variables are supplied on initialization.